### PR TITLE
Add dark mode

### DIFF
--- a/css/auth.css
+++ b/css/auth.css
@@ -1,11 +1,28 @@
 :root {
 	--bgcolor: #E4DCD7;
+	--bgcolor-alt: var(--secondaryColor);
 	--txtcolor: #1A1A1A;
+	--txtcolor-alt: var(--txtcolor)
+	--anchorcolor: #0000B5;
+	--anchorcolor-alt: #4C0083;
+
 	--secondaryColor: #D4C9C4;
 	--tertiaryColor: #12322D;
+
 	--content-width: 35em;
 	--content-padding: 1rem;
 	--border-radius: 8px;
+}
+
+:root.dark {
+	--bgcolor: #1A1A1A;
+	--bgcolor-alt: #242424;
+	--txtcolor: #E4DCD7;
+	--anchorcolor: #8BDAFC;
+	--anchorcolor-alt: #F6B5FF;
+
+	--secondaryColor: #242424;
+	--tertiaryColor: #12322D;
 }
 
 @font-face {
@@ -36,6 +53,7 @@ body > * {
 
 header {
 	display: flex;
+	align-items: center;
 	justify-content: space-between;
 	border-radius: var(--border-radius) var(--border-radius) 0 0;
 }
@@ -49,6 +67,14 @@ footer {
 	background-color: var(--secondaryColor);
 	border-radius: 0 0 var(--border-radius) var(--border-radius);
 	font-size: 0.8em;
+}
+
+a {
+	color: var(--anchorcolor);
+}
+
+a:visited { /* serve anche focused, ma dev'essere un colore diverso */
+	color: var(--anchorcolor-alt);
 }
 
 /* Inputs */
@@ -74,6 +100,19 @@ input[type=submit] {
 	background-color: var(--tertiaryColor);
 }
 
+/* Screen reader */
+
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border-width: 0;
+}
 
 /* CSS reset */
 
@@ -95,4 +134,43 @@ input, button, textarea, select {
 }
 p, h1, h2, h3, h4, h5, h6 {
 	overflow-wrap: break-word;
+}
+
+/* ThemeToggle */
+
+#themeToggle {
+	padding: 0;
+	color: currentcolor;
+	background: transparent;
+	border: 0;
+}
+
+#themeToggle svg {
+	width: 1.8em;
+	fill: none;
+}
+
+#themeToggle svg .sun { stroke: var(--txtcolor); }
+#themeToggle svg .moon { stroke: transparent; }
+
+html.dark #themeToggle svg .sun { stroke: transparent; }
+html.dark #themeToggle svg .moon { stroke: var(--txtcolor); }
+
+/*
+==============
+TMDB ATTRIBUTION
+==============
+*/
+
+.tmdb-attribution {
+	display: flex;
+	gap: 1em;
+}
+
+.tmdb-attribution p {
+	flex: 1 0 100px;
+}
+
+.tmdb-attribution img {
+	width: 3em;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -1,17 +1,31 @@
 :root {
-	/*Colors*/
 	--bgcolor: #E4DCD7;
+	--bgcolor-alt: var(--secondaryColor);
 	--txtcolor: #1A1A1A;
+	--txtcolor-alt: var(--txtcolor)
+	--button-inactive: #20584F;
+	--anchorcolor: #0000B5;
+	--anchorcolor-alt: #4C0083;
+	--link-color: var(--anchorcolor);
+	--visited-color: var(--anchorcolor-alt);
+
 	--secondaryColor: #D4C9C4;
 	--tertiaryColor: #12322D;
-	--button-inactive: #20584F;
-	--link-color: #150CC8;
-	--visited-color: #4C0883;
 
-	/*Global Variables*/
-	--content-width: 80rem;
+	--content-width: 60em;
 	--content-padding: 1rem;
 	--border-radius: 8px;
+}
+
+:root.dark {
+	--bgcolor: #1A1A1A;
+	--bgcolor-alt: #242424;
+	--txtcolor: #E4DCD7;
+	--anchorcolor: #8BDAFC;
+	--anchorcolor-alt: #F6B5FF;
+
+	--secondaryColor: #242424;
+	--tertiaryColor: #12322D;
 }
 
 @font-face {
@@ -55,7 +69,6 @@ body {
 		background-color: #fff;
 	}
 }
-
 
 
 /*
@@ -105,6 +118,10 @@ header li > span {
 header li a {
 	padding: 1em;
 	color: inherit;
+}
+
+header .actions {
+	display: flex;
 }
 
 .accountButton {
@@ -178,7 +195,7 @@ footer .tmdb-attribution {
 
 /*
 ==============
-TMDB ARRTIBUTION
+TMDB ATTRIBUTION
 ==============
 */
 
@@ -192,12 +209,21 @@ TMDB ARRTIBUTION
 	margin-top: 0.4em;
 }
 
+/* Screen reader */
 
-/*
-==============
-CSS REST
-==============
-*/
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border-width: 0;
+}
+
+/* CSS reset */
 
 *, *::before, *::after {
 	box-sizing: border-box;
@@ -218,6 +244,26 @@ input, button, textarea, select {
 p, h1, h2, h3, h4, h5, h6 {
 	overflow-wrap: break-word;
 }
+
+/* ThemeToggle */
+
+#themeToggle {
+	padding: 0;
+	color: currentcolor;
+	background: transparent;
+	border: 0;
+}
+
+#themeToggle svg {
+	width: 1.8em;
+	fill: none;
+}
+
+#themeToggle svg .sun { stroke: var(--txtcolor); }
+#themeToggle svg .moon { stroke: transparent; }
+
+html.dark #themeToggle svg .sun { stroke: transparent; }
+html.dark #themeToggle svg .moon { stroke: var(--txtcolor); }
 
 
 /*
@@ -311,10 +357,6 @@ SIDE BAR
 	justify-content: flex-start;
 	margin-bottom: 0.5em;
 	/*background-color: greenyellow;*/
-}
-
-.item .icon{
-	/*background-color: red;*/
 }
 
 .item .name {
@@ -584,7 +626,7 @@ BREADCRUMB
 	border-color: transparent;
 }
 
-#breadcrumb a:link{
+#breadcrumb a:link{ /* why :link? */
 	color: var(--link-color);
 }
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -34,13 +34,9 @@ services:
     image: phpmyadmin
     env_file:
       - ./phpmyadmin/phpmyadmin.env
-    volumes:
-      - phpmyadmin:/var/www/html
     restart: unless-stopped
 
 volumes:
   caddy_data:
-    external: true
   caddy_config:
-  phpmyadmin:
   mariadb:

--- a/html/login.html
+++ b/html/login.html
@@ -15,7 +15,7 @@
 	</header>
 
 	<main>
-		<h1>Login</h1>
+		<h1 lang="en">Login</h1>
 		<!-- form_messages -->
 		<form method="post" action="login.php">
 			<fieldset>
@@ -33,7 +33,7 @@
 		</form>
 	</main>
 
-	<footer>
+	<footer class="tmdb-attribution">
 		<!-- footer -->
 	</footer>
 </body>

--- a/html/shared_auth.html
+++ b/html/shared_auth.html
@@ -12,6 +12,9 @@
 	<link rel="stylesheet" href="css/auth.css" media="handheld, screen" />
 	<link rel="stylesheet" href="css/print.css" media="print" />
 	<link rel="shortcut icon" type="image/svg" href="img/favicon.svg" />
+	<script src="js/utils.js"></script>
+</head>
+
 	<!-- head_end -->
 </head>
 <body>
@@ -21,15 +24,20 @@
 		<a href="index.php">
 			Torna alla <span lang="en">home</span>
 		</a>
+		<button id="themeToggle" onclick="handleThemeSwitch()">
+			<span class="sr-only">Cambia tema</span>
+			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+				<path class="sun" stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.3m6.4.3-1.6 1.6M21 12h-2.3m-.3 6.4-1.6-1.6m-4.8 2V21m-4.8-4.2-1.6 1.6M5.3 12H3m4.2-4.8L5.6 5.6M15.8 12a3.8 3.8 0 1 1-7.6 0 3.8 3.8 0 0 1 7.6 0z"/>
+				<path class="moon" stroke-linecap="round" stroke-linejoin="round" d="M21.75 15a9.72 9.72 0 0 1-3.75.75 9.75 9.75 0 0 1-9-13.5 9.75 9.75 0 0 0-6 9A9.75 9.75 0 0 0 12.75 21a9.75 9.75 0 0 0 9-6z"/>
+			</svg>
+		</button>
 		<!-- header_end -->
 	</header>
 
 	<footer>
 		<!-- footer_start -->
-		<div class="tmdb-attribution">
-			<img src="img/tmdb.svg" alt="attribution" />
-			<p>Tutti i dati presenti sul sito relativi ai film sono di TMDB. Vedi <a href="about.php#tmdb-about">qui</a> altri dettagli.</p>
-		</div>
+		<img src="img/tmdb.svg" alt="attribution" />
+		<p>Tutti i dati presenti sul sito relativi ai film sono di TMDB. Vedi <a href="about.php#tmdb-about">qui</a> altri dettagli.</p>
 		<!-- footer_end -->
 	</footer>
 </body>

--- a/html/shared_std.html
+++ b/html/shared_std.html
@@ -29,6 +29,13 @@
 			</ul>
 		</nav>
 		<div class="actions">
+			<button id="themeToggle" onclick="handleThemeSwitch()">
+				<span class="sr-only">Cambia tema</span>
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+					<path class="sun" stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.3m6.4.3-1.6 1.6M21 12h-2.3m-.3 6.4-1.6-1.6m-4.8 2V21m-4.8-4.2-1.6 1.6M5.3 12H3m4.2-4.8L5.6 5.6M15.8 12a3.8 3.8 0 1 1-7.6 0 3.8 3.8 0 0 1 7.6 0z"/>
+					<path class="moon" stroke-linecap="round" stroke-linejoin="round" d="M21.75 15a9.72 9.72 0 0 1-3.75.75 9.75 9.75 0 0 1-9-13.5 9.75 9.75 0 0 0-6 9A9.75 9.75 0 0 0 12.75 21a9.75 9.75 0 0 0 9-6z"/>
+				</svg>
+			</button>
 			<button type="button" class="accountButton">
 				<img src="img/account.svg" alt="Accedi al tuo account" width="35" height="35" />
 			</button>

--- a/html/signup.html
+++ b/html/signup.html
@@ -36,7 +36,7 @@
 		</form>
 	</main>
 
-	<footer>
+	<footer class="tmdb-attribution">
 		<!-- footer -->
 	</footer>
 </body>

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,6 +1,6 @@
 /*
  * Gestisce interruttore hamburger menu
-*/
+ */
 
 var isOpen = false;
 function toggleMenu() {
@@ -10,3 +10,44 @@ function toggleMenu() {
 	btn.setAttribute("data-open", isOpen);
 	links.setAttribute("data-open", isOpen);
 }
+
+/*
+ * Gestisce cambio tema alternando chiaro e scuro.
+ * Dà priorità al tema dell'utente, se definito.
+ */
+
+const theme = (() => {
+	// localStorage contiene già la preferenza?
+	if (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) {
+		return localStorage.getItem('theme');
+	}
+	// L'utente ha una preferenza?
+	if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+		return 'dark';
+	}
+	// Fallback
+	return 'light';
+})();
+
+// Cicla tra le due opzioni
+if (theme === 'light') {
+	document.documentElement.classList.remove('dark');
+} else {
+	document.documentElement.classList.add('dark');
+}
+
+// Imposta la preferenza iniziale su localStorage
+window.localStorage.setItem('theme', theme);
+
+// Applica la classe .dark
+const handleThemeSwitch = () => {
+	const element = document.documentElement; // L'elemento è la root <html>
+	element.classList.toggle("dark");
+
+	const isDark = element.classList.contains("dark");
+	localStorage.setItem("theme", isDark ? "dark" : "light");
+}
+
+// Aggiunge funzionalità al bottone
+const button = document.getElementById("themeToggle");
+if (button != null) button.addEventListener("click", handleThemeSwitch);


### PR DESCRIPTION
Include tutte le componenti base per la gestione di due temi, chiaro e scuro. Il CSS avrà probabilmente bisogno di ulteriori aggiustamenti.

- Add JS functions to toggle theme
- Add draft dark-mode colors as CSS vars
- Add theme toggle button to header
- Remove /auth dir
- Add theme toggle button to header
- Add missing script
- Add theme toggle button
- Move theme toggle button ahead of account button
- Define CSS vars with legacy support
- Manual merge of Docker config
- Fix typo
- Use new anchor colors
- Fix copy-paste error
- Add missing lang attribute
- Clean up HTML markup

Al merge si può chiudere la #13.
