### PR TITLE
Set column sizing

### DIFF
--- a/css/mini.css
+++ b/css/mini.css
@@ -116,10 +116,10 @@ nav.dropdown-opened .hamburger-bottom {
 
 .movie-details{
 	margin: 1em;
-
 }
 
 .movie-page{
+	grid-template-columns: auto;
 	grid-template-areas: "a"
 						 "b"
 						 "c";

--- a/css/style.css
+++ b/css/style.css
@@ -548,6 +548,7 @@ MOVIE PAGE
 .movie-page{
 	display: grid;
 	grid-gap: 1.5em;
+	grid-template-columns: auto 1fr;
 	grid-template-areas: "a b"
 						 "a c";
 }


### PR DESCRIPTION
Mancava `grid-template-columns` per definire le dimensioni delle colonne. Su destop è impostato su `auto 1fr`, su mobile `auto` (singola colonna).

Close #125.