### PR TITLE
Breadcrumb

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -137,6 +137,7 @@ BREADCRUMB
 
 #breadcrumb{
 	background-color: var(--secondaryColor);
+	font-size: 0.9em;
 	padding: 0.5em var(--content-padding);
 	border-radius: var(--border-radius);
 }


### PR DESCRIPTION
Ho sistemato l'aspetto grafico della breadcrumb:

- font leggermente più piccolo per renderla meno intrusiva
- stile ora è omogeneo rispetto al resto del sito: applicato raggio del bordo, allineamento del contenuto (attualmente su mobile il contenuto della breadcrumb non è allineato al contenuto del `main` e del `header`)
- rimosse alcune regole di stile non più utili