### PR TITLE
Skip to content ora skippa all'altezza giusta

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -85,6 +85,7 @@ HEADER
 	justify-content: space-between;
 	align-items: center;
 	z-index: 10;
+	height: var(--header-height);
 }
 
 #page-header ul {
@@ -148,6 +149,11 @@ BREADCRUMB
 MAIN
 ==============
 */
+
+#content {
+	padding-top: calc( var(--header-height) ); /* se calc non supportato, non applica né padding né margin */
+	margin-top: calc( var(--header-height) * -1 );
+}
 
 /*
 main > h1, h2{


### PR DESCRIPTION
Saltando al contenuto, la parte alta di `#content` risulta parzialmente nascosta dal header. Ho risolto così:

1. header ha altezza predefinita
1. `#content` ha padding pari all'altezza e margin pari all'opposto dell'altezza

È un trick da webdev. Fix #165.

### Nota a margine

In questa parte del codice

``` css
#content {
	padding-top: calc( var(--header-height) );
	margin-top: calc( var(--header-height) * -1 );
}
```

avrei potuto evitare di usare `calc` per il `padding-top`. Tuttavia un browser che non supporti `calc` (evenienza rara, visto che è supportato da 98%+) applicherebbe comunque il `padding-top`.