### PR TITLE
Fix intestazione di pagina per persona, collezione

### DIFF
--- a/css/mini.css
+++ b/css/mini.css
@@ -92,7 +92,6 @@ PERSON/COLLECTION PAGE
 #person-details,
 #collection-details {
 	flex-direction: column-reverse;
-	align-items: center;
 	gap: 1em;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -922,6 +922,7 @@ PERSON/COLLECTION PAGE
 #collection-details img {
 	flex: 0 1;
 	max-width: 300px;
+	align-self: center;
 }
 
 #person-movies {


### PR DESCRIPTION
- solo l'immagine è centrata, il titolo viene correttamente allineato a sinistra
- flex-basis non veniva applicato nelle pagine con placeholder, perché è largo 750 pt (>300px)

Ho di nuovo usato dimensioni in px perché si tratta di file bitmap.