### PR TITLE
Skip to search bar and search results

### DIFF
--- a/html/cerca.html
+++ b/html/cerca.html
@@ -17,6 +17,8 @@
 	</nav>
 
 	<main id="content">
+		<a href="#searchbar" class="skip-to-content">Vai ai filtri di ricerca</a>
+		<a href="#search-results" class="skip-to-content">Salta ai risultati di ricerca</a>
 		<h1>@@intestazione@@</h1>
 
 		<form method="get" class="search">
@@ -86,7 +88,7 @@
 		</div>
 		<!-- res_buttons_end -->
 
-		<ul class="cards double">
+		<ul id="search-results" class="cards double">
 			<!-- card_start -->
 			<li class="card">
 				<a href="@@link@@">


### PR DESCRIPTION
Aggiunge due link per saltare rispettivamente alla barra di ricerca e ai risultati di ricerca.

Ho scelto di inserirli all'interno del `<main>`, così l'utente skippa al contenuto come di consueto, e poi ha la possibilità di skippare ulteriormente.

Per come viene inserito l'header nello scheletro HTML, le uniche alternative erano quelle di inserire gli aiuti:

- sopra l'header, e quindi prima dello skip to content canonico (scartato: avrebbe rotto convenzione interna).
- sotto l'header, non solo rendendo i link più lontani da raggiungere, ma introducendo il rischio che proprio non venissero visti, poiché lo skip to content porterebbe il focus dell'utente oltre i due link.