### PR TITLE
Remove hidden overflow from `.card` to allow focus outline

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -508,7 +508,6 @@ CARDS
 .card {
 	background-color: var(--secondaryColor);
 	border-radius: var(--border-radius);
-	overflow: hidden;
 }
 
 .card > a {


### PR DESCRIPTION
Fix banalotto.

Close #250.