### PR TITLE
Fix Card: immagini hanno ratio irregolare #294

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -501,7 +501,9 @@ CARDS
 }
 
 .card img {
-	height: 11em;
+	height: 12em;
+	width: 8em;
+	object-fit: cover;
 }
 
 .card .details {


### PR DESCRIPTION
- impostata larghezza immagine
- `object-fit: cover` per posizionare l'immagine all'interno del riquadro (c'è graceful degradation, ma comunque è supportato da 96%+ dei browser)

Close #294