### PR TITLE
Php cosettine

### DIFF
--- a/cerca.php
+++ b/cerca.php
@@ -170,27 +170,23 @@ if (!empty($cerca[0])) {
 	$nav_bottom = Tools::getSection($page, "res_nav_bottom");
 
 	$message = ("Pagina " . ($next+1) . " su " . ceil($tot / $limit) . ". Risultati totali: " . $tot);
-	Tools::replaceAnchor($nav, "message", ("Pagina " . ($next+1) . " su " . ceil($tot / $limit) . ". Risultati totali: " . $tot));
-	Tools::replaceAnchor($nav_bottom, "message_bottom", ("Pagina " . ($next+1) . " su " . ceil($tot / $limit) . ". Risultati totali: " . $tot));
+	Tools::replaceAnchor($nav, "res_message", $message);
+	Tools::replaceAnchor($nav_bottom, "res_message_bottom", $message);
 
-	$is_prev = false;
-	$is_next = false;
 	$query = "cerca_$tipo.php?q=$query" . (($tipo == "film" && $f_nome) ? ("&fn=" . $f_nome . "&fvg=" . $f_val_genere . "&fvp=" . $f_val_paese) : "");
-
-	if ($next > 0) {
-		$is_prev = true;
+	if ($next > 0)
 		Tools::replaceAnchor($nav_bottom, "prev", ($query . "&n=" . ($next-1) . "#results_nav"));
-	} else
+	else
 		Tools::replaceSection($nav_bottom, "prev", "");
-	if (($next + 1) < ceil($tot / $limit)) {
-		$is_next = true;
+	if (($next + 1) < ceil($tot / $limit))
 		Tools::replaceAnchor($nav_bottom, "next", ($query . "&n=" . ($next+1) . "#results_nav"));
-	} else
+	else
 		Tools::replaceSection($nav_bottom, "next", "");
+
 	Tools::replaceSection($page, "res_nav", $nav, true);
 	Tools::replaceSection($page, "res_nav_bottom", $nav_bottom, true);
 } else {
-	Tools::replaceAnchor($page, "message", "Questa ricerca non ha prodotto risultati");
+	Tools::replaceAnchor($page, "res_message", "Questa ricerca non ha prodotto risultati");
 	Tools::replaceSection($page, "res_nav_bottom", "");
 	Tools::replaceSection($page, "results", "");
 }

--- a/html/cerca.html
+++ b/html/cerca.html
@@ -60,9 +60,7 @@
 
 		<!-- res_nav_start -->
 		<nav id="results_nav" class="results-navigation" aria-label="Indicazione numero di pagina">
-			<!-- message_start -->
-			<p role="status" class="resultMessage">@@message@@</p>
-			<!-- message_end -->
+			<p role="status" class="resultMessage">@@res_message@@</p>
 		</nav>
 		<!-- res_nav_end -->
 
@@ -89,9 +87,7 @@
 
 		<!-- res_nav_bottom_start -->
 		<nav id="results_nav_bottom" class="results-navigation" aria-label="Naviga tra i risultati di ricerca">
-			<!-- message_start -->
-			<p class="resultMessage" aria-hidden="true">@@message_bottom@@</p>
-			<!-- message_end -->
+			<p class="resultMessage" aria-hidden="true">@@res_message_bottom@@</p>
 			<!-- prev_start -->
 			<a href="@@prev@@" class="link-button res-prev" title="Pagina precedente dei risultati di ricerca">
 				<svg viewBox="0 0 41 41" xmlns="http://www.w3.org/2000/svg">
@@ -108,8 +104,6 @@
 			<!-- next_end -->
 		</nav>
 		<!-- res_nav_bottom_end -->
-
-		<!-- results_end -->
 	</main>
 
 	<!-- footer -->


### PR DESCRIPTION
La navigazione tra i risultati di ricerca in `php_cosette` non mi convince perché:

1. c'è un paragrafo con `role=status` e `aria-hidden=true`
2. non è possibile raggiungere col tab i pulsanti di navigazione sopra i risultati di ricerca

Ho cercato di migliorare la situazione mostrando in alto solo il numero di pagina e i risultati (con `role=status`) e sotto la stessa cosa (ma il paragrafo è hidden e non ha ruolo), con l'aggiunta dei tasti di navigazione.

Dimmi cosa ne pensi. Non dovrei aver fatto castronerie col PHP