### PR TITLE
Fix responsive behaviour of container children

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -452,7 +452,7 @@ INDEX
 }
 
 .container > .text {
-	flex: 1 0;
+	flex: 1 0 15em;
 }
 
 .product-image {


### PR DESCRIPTION
Semplicemente imposta la larghezza minima del testo alla larghezza dell'immagine, così non viene schiacciato sul lato destro.