### PR TITLE
Piccola miglioria grafica al messaggio dal server

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1221,10 +1221,13 @@ SERVER MESSAGES
 
 #server-message {
 	margin: 1em 0;
-	padding: 1em;
-	border: 0.4em solid;
+	border: 0.2em solid;
 	border-radius: var(--border-radius);
 	list-style-type: none;
+}
+
+#server-message li {
+	padding: 0.5em;
 }
 
 #server-message.success {


### PR DESCRIPTION
Modificato il padding e la dimensione del bordo per i messaggi dal server.
Prima:
<img width="1680" alt="Schermata 2023-01-29 alle 18 53 56" src="https://user-images.githubusercontent.com/39963191/215346317-250f0032-6bca-43be-962c-0a94887cd806.png">

Dopo:
<img width="1680" alt="Schermata 2023-01-29 alle 19 03 07" src="https://user-images.githubusercontent.com/39963191/215346310-8257288f-9534-47da-9364-a69158969d50.png">
