### PR TITLE
Testi in pagina statistiche

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -912,6 +912,7 @@ tbody tr:nth-child(odd) {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 1em;
+	margin-bottom: 1.5em;
 }
 
 #stats-summary li {
@@ -929,6 +930,10 @@ tbody tr:nth-child(odd) {
 #stats-summary .number {
 	font-size: 3em;
 	font-weight: 600;
+}
+
+.stats-page p {
+	text-align: center;
 }
 
 .stats-page h2 {

--- a/html/stats.html
+++ b/html/stats.html
@@ -31,10 +31,7 @@
 			</li>
 		</ul>
 
-		<p>Tutte le statistiche sono basate sui film presenti nelle tue liste.</p>
-
 		<!-- message_start -->
-		<h2>Statistiche dettagliate</h2>
 		<p>Aggiungi almeno un film ad una lista per vedere le statistiche.</p>
 		<!-- message_end -->
 
@@ -91,7 +88,7 @@
 		<!-- lunghi_end -->
 
 		<div id="user-additional-actions">
-			<a href="lists.php">Vai alle tue liste</a>
+			<p>Tutte le statistiche sono basate sui film presenti nelle tue liste. <a href="lists.php">Vai alle tue liste</a>.</p>
 		</div>
 
 	</main>


### PR DESCRIPTION
- tutti i paragrafi della pagina statistiche sono centrati (mancava il `<p>` di avviso quando non ci sono film in lista)
- rimosso il tag `<h2>` mostrato quando non ci sono film in lista
- spostato disclaimer sotto alle tabelle